### PR TITLE
Add fallback for classList function on the DOM Element

### DIFF
--- a/src/nanoJS.js
+++ b/src/nanoJS.js
@@ -46,12 +46,24 @@ var nano = function(s){
   },
   toggleClass: function (v) {
     return this.each(function (i) {
-      i.classList.toggle(v);
+      if (i.classList) {
+        i.classList.toggle(v);
+      } else {
+        if (!i.className || i.className.indexOf(v) === -1) {
+          i.className += ' ' + v;
+        } else {
+          i.className.replace(v, '');
+        }
+      }
     });
   },
   removeClass: function (v) {
     return this.each(function (i) {
-      i.classList.remove(v);
+      if (i.classList) {
+        i.classList.remove(v);
+      } else {
+        i.className.replace(v, '');
+      }
     });
   },
   html: function (v) {


### PR DESCRIPTION
Check has been added for classList function on the DOM Element so the library works on ie 9 browser.