### PR TITLE
Add a eq function to select a class node with a count number

### DIFF
--- a/src/nanoJS.js
+++ b/src/nanoJS.js
@@ -5,6 +5,10 @@ var nano = function(s){
 };
 
  nano.prototype = {
+  eq: function(n){
+    this.value = [this.value[n]];
+    return this;
+  },
   each: function(fn) {
     [].forEach.call(this.value, fn);
     return this;


### PR DESCRIPTION
Hi,
I don't know how to select a class node with a count number in nanoJS.

Therefore, i add a eq function in nanoJS to select a class node with a count number as same as jquery . 
$(".test").eq(0).html("hello world");

If there is a method to select ,please tell me and i will close this pr.
