### PR TITLE
add length attribute to nano objects

### DIFF
--- a/src/nanoJS.js
+++ b/src/nanoJS.js
@@ -5,6 +5,7 @@ var nano = function(s) {
     if (typeof s === "object") {
         this.value = [s];
     }
+    this.length = this.value.length;
 };
 
  nano.prototype = {


### PR DESCRIPTION
Adding the length attribute to nano objects allows for easily checking if or how many DOM Elements are selected.

$('selector').length  // int
$('selector').length > 0  // item exists